### PR TITLE
Small Bugfix

### DIFF
--- a/content/js/application.js
+++ b/content/js/application.js
@@ -154,13 +154,15 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
                         raw: request.response
                     };
 
-                // TODO: this is not implemented correctly for binary filetypes
-                // - raw should be a hex dump and (for images) a preview should
-                //   be displayed
+                if (contentType) {
+                    // TODO: this is not implemented correctly for binary filetypes
+                    // - raw should be a hex dump and (for images) a preview should
+                    //   be displayed
 
-                // If the MIME type is text/*, then display a preview of the document
-                if(contentType.substring(0, 5) == 'text/')
-                    response['preview'] = 'data:' + contentType + ',' + encodeURIComponent(request.response);
+                    // If the MIME type is text/*, then display a preview of the document
+                    if(contentType.substring(0, 5) == 'text/')
+                        response['preview'] = 'data:' + contentType + ',' + encodeURIComponent(request.response);
+                }
 
                 // Try to parse the response to JSON
                 try {

--- a/content/js/application.js
+++ b/content/js/application.js
@@ -144,9 +144,9 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
         // Check for completion of the request and display the results
         readyStateChange: function(request) {
             if(request.readyState === 4) {
-                var headers = this.parseHeaders(request.getAllResponseHeaders()),
-                    contentType = request.getResponseHeader('Content-Type'),
-                    response = {
+                var headers = this.parseHeaders(request.getAllResponseHeaders());
+                var contentType = request.getResponseHeader('Content-Type');
+                var response = {
                         status: request.status,
                         statusText: request.statusText,
                         headers: headers,
@@ -157,10 +157,11 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
                 // TODO: this is not implemented correctly for binary filetypes
                 // - raw should be a hex dump and (for images) a preview should
                 //   be displayed
-
-                // If the MIME type is text/*, then display a preview of the document
-                if(contentType.substring(0, 5) == 'text/')
-                    response['preview'] = 'data:' + contentType + ',' + encodeURIComponent(request.response);
+                if(contentType !== null) {
+                    // If the MIME type is text/*, then display a preview of the document
+                    if(contentType.substring(0, 5) == 'text/') 
+                        response['preview'] = 'data:' + contentType + ',' + encodeURIComponent(request.response);
+                }
 
                 // Try to parse the response to JSON
                 try {
@@ -168,6 +169,7 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
                 } catch (e) {
                     response['json'] = false;
                 }
+
 
                 // Display the response and hide the progress dialog
                 this.set('response', response);

--- a/content/js/application.js
+++ b/content/js/application.js
@@ -144,9 +144,9 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
         // Check for completion of the request and display the results
         readyStateChange: function(request) {
             if(request.readyState === 4) {
-                var headers = this.parseHeaders(request.getAllResponseHeaders());
-                var contentType = request.getResponseHeader('Content-Type');
-                var response = {
+                var headers = this.parseHeaders(request.getAllResponseHeaders()),
+                    contentType = request.getResponseHeader('Content-Type'),
+                    response = {
                         status: request.status,
                         statusText: request.statusText,
                         headers: headers,
@@ -157,11 +157,10 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
                 // TODO: this is not implemented correctly for binary filetypes
                 // - raw should be a hex dump and (for images) a preview should
                 //   be displayed
-                if(contentType !== null) {
-                    // If the MIME type is text/*, then display a preview of the document
-                    if(contentType.substring(0, 5) == 'text/') 
-                        response['preview'] = 'data:' + contentType + ',' + encodeURIComponent(request.response);
-                }
+
+                // If the MIME type is text/*, then display a preview of the document
+                if(contentType.substring(0, 5) == 'text/')
+                    response['preview'] = 'data:' + contentType + ',' + encodeURIComponent(request.response);
 
                 // Try to parse the response to JSON
                 try {
@@ -169,7 +168,6 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
                 } catch (e) {
                     response['json'] = false;
                 }
-
 
                 // Display the response and hide the progress dialog
                 this.set('response', response);


### PR DESCRIPTION
If the server send only HTTP status code (404, 200, 500) without content, the addon dies.
This patch does not fix the whole issue:
 - on the first request (`Send` button click) the response is not previewed, but on the second request everything looks fine.
