### PR TITLE
'http://' is not appended to URL starting with " http://" anymore

### DIFF
--- a/content/js/application.js
+++ b/content/js/application.js
@@ -236,7 +236,7 @@ RESTEasy.ApplicationController = Ember.Controller.extend({
 
             // If url does not start with http://, we help the user out and add it for them
             // Improvements and suggestions to behaviour welcome
-            if (!/^(http:\/\/)/.test(url)) {
+            if (!/^\s*(http:\/\/)/.test(url)) {
               url = 'http://' + url;
             }
 


### PR DESCRIPTION
changed the regex to account for leading whitespace (not that hard to forget them there)