### PR TITLE
title fixed to receive translation

### DIFF
--- a/content/resteasy.html
+++ b/content/resteasy.html
@@ -126,7 +126,7 @@
                 {{#tab-content title="request.tab.collections"}}
 
                     <!-- Collections tab -->
-                    <h4>Saved requests</h4>
+                    <h4>{{tr 'request.saved'}}</h4>
                     <table class="table">
                         {{#each collections}}
                             <tr class="hoverhand">

--- a/locale/en-US/resteasy.properties
+++ b/locale/en-US/resteasy.properties
@@ -13,6 +13,7 @@ highlight.notice=Syntax highlighting was not automatically applied since the con
 highlight.highlight=Highlight
 request.send=Send
 request.save=Save request
+request.saved=Saved requests
 request.tab.request=Request
 request.tab.collections=Collections
 request.collections.title=Collections

--- a/locale/pt-BR/resteasy.properties
+++ b/locale/pt-BR/resteasy.properties
@@ -13,6 +13,7 @@ highlight.notice=A resposta é maior que 10 KiB. O destaque da sintaxe pode demo
 highlight.highlight=Destacar de qualquer forma
 request.send=Enviar
 request.save=Salvar requisição
+request.saved=Requisições Salvas
 request.tab.request=Requisição
 request.tab.collections=Coleções
 request.collections.title=Coleções


### PR DESCRIPTION
before the text "Save requests" I could not translate.
![screen shot 2016-06-23 at 16 04 11](https://cloud.githubusercontent.com/assets/8291055/16320001/9ab62b9a-3963-11e6-818d-99ad99d11bca.png)

now I can
![screen shot 2016-06-23 at 16 58 22](https://cloud.githubusercontent.com/assets/8291055/16320024/bcf11346-3963-11e6-8ff1-491f19dbaa6a.png)

Signed-off-by: Walter Nascimento <walter.nascimento.barroso@gmail.com>